### PR TITLE
feat: print type when empty; add fundamental type

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Next: (4) err-std
  │  │  code.gopub.tech/example.TestErrors
  │  │  	/go/src/code.gopub.tech/example/main_test.go:16
  │  └─ [...repeated from below...]
- ├─ Wraps: (7)
+ ├─ Wraps: (7) attached stack trace
  │  │ -- stack trace:
  │  │ code.gopub.tech/example.TestErrors
  │  │ 	/go/src/code.gopub.tech/example/main_test.go:17
@@ -94,18 +94,17 @@ Next: (4) err-std
  │ Next: (8) err-cdb
  │  │  new
  │  └─ line
- └─ Wraps: (9) attached stack trace
-    │ -- stack trace:
-    │ code.gopub.tech/example.TestErrors
-    │ 	/go/src/code.gopub.tech/example/main_test.go:18
-    │ testing.tRunner
-    │ 	/sdk/go1.21.6/src/testing/testing.go:1595
-    │ runtime.goexit
-    │ 	/sdk/go1.21.6/src/runtime/asm_amd64.s:1650
-   Next: (10) err-this
+ └─ Wraps: (9) err-this
     │  new
-    └─ line
-Error types: (1) *errors.withStack (2) *errors.withPrefix (3) *errors.withStack (4) *errors.joinError (5) *errors.errorString (6) *errors.fundamental (7) *withstack.withStack (8) *errutil.leafError (9) *errors.withStack (10) *errors.errorString
+    │  line
+    │  -- stack trace:
+    │  code.gopub.tech/example.TestErrors
+    │  	/go/src/code.gopub.tech/example/main_test.go:18
+    │  testing.tRunner
+    │  	/sdk/go1.21.6/src/testing/testing.go:1595
+    │  runtime.goexit
+    └─ 	/sdk/go1.21.6/src/runtime/asm_amd64.s:1650
+Error types: (1) *errors.withStack (2) *errors.withPrefix (3) *errors.withStack (4) *errors.joinError (5) *errors.errorString (6) *errors.fundamental (7) *withstack.withStack (8) *errutil.leafError (9) *errors.fundamental
 ```
 
 ## License

--- a/errors_test.go
+++ b/errors_test.go
@@ -28,13 +28,15 @@ func TestNew(t *testing.T) {
 }
 
 func TestErrorf(t *testing.T) {
-	err := errors.Errorf("arg=%v", errLeafNew)
+	err := errors.Errorf("arg=%v", 1)
+	print(t, err)
+	err = errors.Errorf("arg=%v", errLeafNew)
 	print(t, err)
 	err = errors.Errorf("wrap1: %w", errLeafNew)
 	print(t, err)
 	err = errors.Errorf("wrap2: %w, %w", errLeafNew, errFmt)
 	print(t, err)
-	print(t, errors.Formattable(newJoin(errFmt, errLeafNew)))
+	print(t, errors.F(newJoin(errFmt, errLeafNew)))
 }
 
 type onlyJoin struct {
@@ -65,9 +67,9 @@ func TestCause(t *testing.T) {
 	err2 := errors.Errorf("wrap: %w", err)
 
 	c := errors.Cause(err2)
-	// errLeafNew: withStack{leafError, stack}
+	// errLeafNew: fundamental{string, stack}
 	typ := fmt.Sprintf("%T", c)
-	if typ != "*errors.errorString" {
+	if typ != "*errors.fundamental" {
 		t.Errorf("cause failed: %v", typ)
 	}
 

--- a/format.go
+++ b/format.go
@@ -244,7 +244,7 @@ func (s *state) printErrorString() {
 // print 格式化输出每个错误节点
 func (s *state) print(depth int, entry *formatEntry, prefix string, errType map[int]string) {
 	index := len(errType) + 1 // 计数
-	errType[index] = fmt.Sprintf("%T", entry.err)
+	errType[index] = reflect.TypeOf(entry.err).String()
 
 	if index == 1 { // 第一个特殊处理 不需要竖线开头
 		fmt.Fprintf(&s.finalBuf, "\n(1)")
@@ -333,8 +333,14 @@ func (s *state) printOne(prefix string, entry *formatEntry) {
 		}
 	}
 
+	tmp := sb.String()
+	if tmp == "" {
+		s.finalBuf.WriteString(" " + reflect.TypeOf(entry.err).String())
+		return
+	}
+
 	// 替换换行符号后再实际输出
-	str := replacePrefix(sb.String(), prefix, len(entry.wraps) == 0)
+	str := replacePrefix(tmp, prefix, len(entry.wraps) == 0)
 	s.finalBuf.WriteString(str)
 }
 
@@ -417,7 +423,7 @@ type formatEntry struct {
 
 // String is used for debugging only.
 func (e formatEntry) String() string {
-	return fmt.Sprintf("entry{%T,%v, %q, %q}", e.err, e.elidedStackTrace, e.simple, e.detail)
+	return fmt.Sprintf("entry{%T, %v, %q, %q}", e.err, e.elidedStackTrace, e.simple, e.detail)
 }
 
 // Write implements fmt.State.

--- a/format.go
+++ b/format.go
@@ -326,6 +326,9 @@ func (s *state) printOne(prefix string, entry *formatEntry) {
 		sb.Write(entry.detail)
 	}
 	if entry.stackTrace != nil {
+		if sb.String() == "" {
+			sb.WriteString(" attached stack trace")
+		}
 		sb.WriteString("\n-- stack trace:")
 		sb.WriteString(StackDetail(entry.stackTrace))
 		if entry.elidedStackTrace {

--- a/format_test.go
+++ b/format_test.go
@@ -36,3 +36,19 @@ func TestDetail(t *testing.T) {
 		}
 	}
 }
+
+type Err struct {
+	err error
+	foo string
+}
+
+func newErr(err error) error { return &Err{err: err, foo: "foo"} }
+func (e *Err) Error() string { return e.err.Error() }
+func (e *Err) Unwrap() error { return e.err }
+
+func TestEmpty(t *testing.T) {
+	err := errors.Errorf("newErr")
+	err = newErr(err)
+	t.Logf("err=%+v", errors.F(err))
+	t.Logf("err=%+v", errors.Wrapf(err, "prefix"))
+}

--- a/fundamental.go
+++ b/fundamental.go
@@ -1,0 +1,17 @@
+package errors
+
+import "fmt"
+
+var _ error = (*fundamental)(nil)
+var _ fmt.Formatter = (*fundamental)(nil)
+
+type fundamental struct {
+	string
+	*stack
+}
+
+func (e *fundamental) Error() string { return e.string }
+
+func (e *fundamental) Format(s fmt.State, verb rune) {
+	FormatError(e, s, verb)
+}


### PR DESCRIPTION
- `errors.New` and `errors.Errorf`(when args not contains error type) now returns `*errors.fundamental`
- when a wrap error do not add any additional message, then print it's type in detail mode

```go
type Err struct {
	err error
	foo string
}

func newErr(err error) error { return &Err{err: err, foo: "foo"} }
func (e *Err) Error() string { return e.err.Error() }
func (e *Err) Unwrap() error { return e.err }

func TestEmpty(t *testing.T) {
	err := errors.Errorf("newErr") // Line 50
	err = newErr(err)
	fmt.Printf("err=%+v\n", errors.Wrapf(err, "prefix")) // Line 52
}

```

Output:
// note the (3) and (4) error
```
err=prefix: newErr
(1) attached stack trace
 │ -- stack trace:
 │ code.gopub.tech/errors_test.TestEmpty
 │ 	/go/src/code.gopub.tech/errors/format_test.go:52
 │ [...repeated from below...]
Next: (2) prefix
Next: (3) *errors_test.Err
Next: (4) newErr
 │  -- stack trace:
 │  code.gopub.tech/errors_test.TestEmpty
 │  	/go/src/code.gopub.tech/errors/format_test.go:50
 │  testing.tRunner
 │  	/sdk/go1.21.6/src/testing/testing.go:1595
 │  runtime.goexit
 └─ 	/sdk/go1.21.6/src/runtime/asm_amd64.s:1650
Error types: (1) *errors.withStack (2) *errors.withPrefix (3) *errors_test.Err (4) *errors.fundamental
```